### PR TITLE
Update xyz2graph: pip installation and API method changes

### DIFF
--- a/MASSIVEChem.yml
+++ b/MASSIVEChem.yml
@@ -54,6 +54,6 @@ dependencies:
       - uc-micro-py==1.0.3
       - urllib3==2.2.1
       - webencodings==0.5.1
-      - xyz2graph==2.0.0
+      - xyz2graph==3.2.0
       - xyzservices==2024.4.0
 

--- a/README.md
+++ b/README.md
@@ -112,12 +112,7 @@ If not, install them using the following commands. (Bear in mind that the packag
 pip install bokeh
 pip install rdkit
 pip install panel
-```
-
-Additionally, the package 'xyz2graph' is required to run the 3D imaging functionallity in the function 'spectrum'. This package is not pip-installable, so to intall it yourself, the following command needs to be run.
-
-```bash
-python -m pip install git+https://github.com/zotko/xyz2graph.git
+pip install xyz2graph
 ```
 
 

--- a/scripts/smiles_to_3D_plot.py
+++ b/scripts/smiles_to_3D_plot.py
@@ -1,7 +1,7 @@
 from rdkit import Chem
 from rdkit.Chem import AllChem
 import tempfile
-from xyz2graph import MolGraph, to_plotly_figure
+from xyz2graph import MolGraph
 
 def smiles_to_3D_plot(mol_smi):
 
@@ -43,7 +43,7 @@ def smiles_to_3D_plot(mol_smi):
     mg.read_xyz(tmp_path)
 
     # Create the Plotly figure object
-    fig = to_plotly_figure(mg)
+    fig = mg.to_plotly()
 
     return fig
 

--- a/scripts/spectrum_3D.py
+++ b/scripts/spectrum_3D.py
@@ -9,7 +9,7 @@ import base64
 from io import BytesIO
 import panel as pn
 import tempfile
-from xyz2graph import MolGraph, to_plotly_figure
+from xyz2graph import MolGraph
 
 def spectrum_3D(mol_smi, imprecision_True_False, apparatus_resolution):
     #---------------------------------------------------------------------------------------------#
@@ -605,7 +605,7 @@ def spectrum_3D(mol_smi, imprecision_True_False, apparatus_resolution):
     mg.read_xyz(tmp_path)
 
     # Create the Plotly figure object
-    fig = to_plotly_figure(mg)
+    fig = mg.to_plotly()
 
 
     # Converts all the graphs to pane to combine Bokeh and Plotly

--- a/src/MASSiveChem/MASSiveChem.py
+++ b/src/MASSiveChem/MASSiveChem.py
@@ -8,7 +8,7 @@ from bokeh.models.widgets import DataTable, TableColumn
 from bokeh.layouts import row, column
 from io import BytesIO
 import tempfile
-from xyz2graph import MolGraph, to_plotly_figure
+from xyz2graph import MolGraph
 import panel as pn
 
 #main functions:
@@ -1223,7 +1223,7 @@ def spectrum_3D(mol_smi, imprecision_True_False, apparatus_resolution):
     mg.read_xyz(tmp_path)
 
     # Create the Plotly figure object
-    fig = to_plotly_figure(mg)
+    fig = mg.to_plotly()
 
 
     # Converts all the graphs to pane to combine Bokeh and Plotly
@@ -2155,6 +2155,6 @@ def smiles_to_3D_plot(mol_smi):
     mg.read_xyz(tmp_path)
 
     # Create the Plotly figure object
-    fig = to_plotly_figure(mg)
+    fig = mg.to_plotly()
 
     return fig


### PR DESCRIPTION
I maintain xyz2graph, which is now available on PyPI.
This PR:
- Updates installation from git to simple `pip install xyz2graph`
- Updates code to use MolGraph.to_plotly() method instead of deprecated to_plotly_graph() function